### PR TITLE
Changed pop_jobs to reflect changes in vanilla and fixed the subject tax bug

### DIFF
--- a/Change log.txt
+++ b/Change log.txt
@@ -101,3 +101,11 @@
 -Bank corp nerfed, branch offices give 12 energy, was 15, bank manager jobs added reduced to 1 from 2, 1 clerk job added
 -Bank corp branch office buildings restricted to bank corp civic
 -guaranteed most rare system spawns
+
+17/08/2020 - RoAdd/adriangaro
+
+-Implemented changes to pop_jobs which reflect vanilla 2.7 changes. This means roboticists are consuming alloys instead of minerals, all subsidies edicts now apply the correct upkeep increase as in vanilla (previously the edict were basically free besides the influence).
+-Applied trifty trait and nuumismatic administration traits to all jobs added by SCM(bankers, mercenaries, socialist traders).
+-Applied subsidies upkeep increase for jobs added by SCM(deep miners, labour heroes, geo engineers, xeno biologists).
+-Changed subject_tax economic category to not inherit diplomacy upkeep multipliers. This caused the subject taxes to be increased masively for fanatic xenophobes and reduced dramatically for xenophile empires and nations with diplomacy opener.
+-Added to economic categories for bankers and socialist traders since they would receive productivity increases from miners, specifically in the case of subsidies.

--- a/SCM-Overhaul/common/economic_categories/00_common_categories.txt
+++ b/SCM-Overhaul/common/economic_categories/00_common_categories.txt
@@ -1163,7 +1163,6 @@ claims = {
 }
 
 subject_tax = {
-	parent = diplomacy
 }
 
 envoy_costs = {

--- a/SCM-Overhaul/common/economic_categories/ethic_rebuild_categories.txt
+++ b/SCM-Overhaul/common/economic_categories/ethic_rebuild_categories.txt
@@ -1,0 +1,23 @@
+planet_bank_managers = {
+	parent = planet_jobs
+	generate_add_modifiers = {
+		produces
+        upkeep
+	}
+	generate_mult_modifiers = {
+		produces
+		upkeep
+	}
+}
+
+planet_socialist_traders = {
+	parent = planet_jobs
+	generate_add_modifiers = {
+		produces
+        upkeep
+	}
+	generate_mult_modifiers = {
+		produces
+		upkeep
+	}
+}

--- a/SCM-Overhaul/common/pop_jobs/01_ruler_jobs.txt
+++ b/SCM-Overhaul/common/pop_jobs/01_ruler_jobs.txt
@@ -143,6 +143,8 @@ head_researcher = {
 		}
 		modifier = {
 			factor = 0.01
+			exists = planet
+			exists = planet.controller
 			planet.controller = {
 				OR = {
 					is_country_type = swarm
@@ -287,6 +289,8 @@ high_priest = {
 		# crisis purge
 		modifier = {
 			factor = 0.01
+			exists = planet
+			exists = planet.controller
 			planet.controller = {
 				OR = {
 					is_country_type = swarm
@@ -405,6 +409,8 @@ administrator = {
 		# crisis purge
 		modifier = {
 			factor = 0.01
+			exists = planet
+			exists = planet.controller
 			planet.controller = {
 				OR = {
 					is_country_type = swarm
@@ -473,6 +479,8 @@ noble = {
 		# crisis purge
 		modifier = {
 			factor = 0.01
+			exists = planet
+			exists = planet.controller
 			planet.controller = {
 				OR = {
 					is_country_type = swarm
@@ -612,6 +620,8 @@ merchant = {
 		# crisis purge
 		modifier = {
 			factor = 0.01
+			exists = planet
+			exists = planet.controller
 			planet.controller = {
 				OR = {
 					is_country_type = swarm
@@ -731,6 +741,8 @@ executive = {
 		# crisis purge
 		modifier = {
 			factor = 0.01
+			exists = planet
+			exists = planet.controller
 			planet.controller = {
 				OR = {
 					is_country_type = swarm

--- a/SCM-Overhaul/common/pop_jobs/02_specialist_jobs.txt
+++ b/SCM-Overhaul/common/pop_jobs/02_specialist_jobs.txt
@@ -441,6 +441,15 @@ foundry = {
 			minerals = 6
 		}
 		upkeep = {
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = forge_subsidies
+				}
+			}
+			energy = 1
+		}
+		upkeep = {
 		   	trigger = {
 				exists = owner
 				owner = { is_green = yes }
@@ -449,8 +458,6 @@ foundry = {
 		}		
 
 	}
-
-
 
 	weight = {
 		weight = @specialist_job_weight
@@ -652,6 +659,10 @@ enforcer = {
 			is_enslaved = yes
 			has_slavery_type = { type = slavery_indentured }
 		}
+		modifier = {
+			factor = 2
+			has_trait = trait_lithoid
+		}
 	}
 }
 
@@ -670,6 +681,10 @@ telepath = {
 
 	possible = {
 		specialist_job_check_trigger = yes
+		OR = {
+			has_trait = trait_latent_psionic
+			has_trait = trait_psionic
+		}
 	}
 
 	resources = {
@@ -810,6 +825,15 @@ artisan = {
 		}
 		upkeep = {
 			minerals = 6
+		}
+		upkeep = {
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = industrial_subsidies
+				}
+			}
+			energy = 1
 		}
 		upkeep = {
 		   	trigger = {
@@ -1552,7 +1576,7 @@ roboticist = {
 	resources = {
 		category = planet_pop_assemblers
 		upkeep = {
-			minerals = 6
+			alloys = 2
 		}
 	}
 

--- a/SCM-Overhaul/common/pop_jobs/03_worker_jobs.txt
+++ b/SCM-Overhaul/common/pop_jobs/03_worker_jobs.txt
@@ -141,6 +141,15 @@ technician = {
 			}
 			energy = 2
 		}
+		upkeep = {
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = capacity_subsidies
+				}
+			}
+			energy = 0.5
+		}
 	}
 
 	weight = {
@@ -283,6 +292,15 @@ miner = {
 		produces = {
 			minerals = 4
 		}
+		upkeep = {
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = mining_subsidies
+				}
+			}
+			energy = 0.5
+		}
 		produces = {
 			trigger = {
 				owner = {
@@ -417,6 +435,15 @@ crystal_miner = {
 		produces = {
 			rare_crystals = 2
 		}
+		upkeep = {
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = mining_subsidies
+				}
+			}
+			energy = 0.5
+		}
 	}
 
 	weight = {
@@ -509,6 +536,15 @@ gas_extractor = {
 		produces = {
 			exotic_gases = 2
 		}
+		upkeep = {
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = mining_subsidies
+				}
+			}
+			energy = 0.5
+		}
 	}
 
 	weight = {
@@ -600,6 +636,15 @@ mote_harvester = {
 		category = planet_miners
 		produces = {
 			volatile_motes = 2
+		}
+		upkeep = {
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = mining_subsidies
+				}
+			}
+			energy = 0.5
 		}
 	}
 
@@ -706,6 +751,15 @@ farmer = {
 				}
 			}
 			food = -1
+		}
+		upkeep = {
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = farming_subsidies
+				}
+			}
+			energy = 0.5
 		}
 	}
 
@@ -1017,6 +1071,10 @@ soldier = {
 		modifier = {
 			factor = 0
 			can_be_soldier = no
+		}
+		modifier = {
+			factor = 2
+			has_trait = trait_lithoid
 		}
 	}
 }

--- a/SCM-Overhaul/common/pop_jobs/ethic_rebuild_jobs.txt
+++ b/SCM-Overhaul/common/pop_jobs/ethic_rebuild_jobs.txt
@@ -64,6 +64,15 @@ deep_miner = {
 			}
 			energy = 1
 		}
+		upkeep = { # Added since it is affected by mining subsidies as it increases overall output of all miners
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = mining_subsidies
+				}
+			}
+			energy = 0.5
+		}
 	}
 
 	weight = {
@@ -438,8 +447,17 @@ labour_hero = {
              trigger = { owner = { is_lithoid = yes  }}
              food = -2
              minerals = 2
-        }		
+		}		
 
+		upkeep = { # Added since it is affected by mining subsidies as it increases overall output of all miners
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = mining_subsidies
+				}
+			}
+			energy = 0.5
+		}
 	}
 
 	weight = {
@@ -606,6 +624,17 @@ mercenary = {
 		trade_value_add = 1
 	}
 
+	triggered_planet_modifier = {
+		potential = {
+			OR = {
+				has_trait = trait_thrifty
+				has_trait = trait_nuumismatic_administration
+			}
+		}
+		modifier = {
+			trade_value_add = 0.25
+		}
+	}
 
 	resources = {
 		category = planet_soldiers
@@ -657,15 +686,11 @@ mercenary = {
 	}
 }
 
-
-
-
-
 transcend = {
-category = specialist
-condition_string = SPECIALIST_JOB_TRIGGER
-building_icon = building_psi_corps
-clothes_texture_index = 5
+	category = specialist
+	condition_string = SPECIALIST_JOB_TRIGGER
+	building_icon = building_psi_corps
+	clothes_texture_index = 5
 
 
 	possible_pre_triggers = {
@@ -675,30 +700,26 @@ clothes_texture_index = 5
 	}
 
 
-possible = {
-complex_specialist_job_check_trigger = yes
-}
+	possible = {
+		complex_specialist_job_check_trigger = yes
+	}
 
-resources = {
-category = planet_telepaths
-produces = {
-unity = 4
-society_research = 3
-physics_research = 2
-engineering_research = 1
+	resources = {
+		category = planet_telepaths
+		produces = {
+			unity = 4
+			society_research = 3
+			physics_research = 2
+			engineering_research = 1
+		}
+		upkeep = {
+			energy = 2
+		}
+	}
 
-}
-upkeep = {
-energy = 2
-}
-}
-
-planet_modifier = {
-planet_crime_add = -35
-}
-
-
-
+	planet_modifier = {
+		planet_crime_add = -35
+	}
 
 	weight = {
 		weight = @specialist_job_weight
@@ -874,7 +895,6 @@ druid = {
 }
 
 
-
 geoengineer = {
 	category = specialist
 	condition_string = SPECIALIST_JOB_TRIGGER
@@ -900,6 +920,16 @@ geoengineer = {
 		}
 		upkeep = {
 			consumer_goods = 1
+		}
+
+		upkeep = { # Added since it is affected by research subsidies as it increases overall output of all researchers
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = research_subsidies
+				}
+			}
+			energy = 1
 		}
 	}
 
@@ -985,6 +1015,16 @@ xenobiologist  = {
 
 		upkeep = {
 			consumer_goods = 1
+		}
+
+		upkeep = { # Added since it is affected by research subsidies as it increases overall output of all researchers
+			trigger = {
+				exists = owner
+				owner = {
+					has_edict = research_subsidies
+				}
+			}
+			energy = 1
 		}
 	}
 
@@ -1166,10 +1206,6 @@ supervisor = {
 		planet_jobs_society_research_produces_mult = 0.05
 	}
 
-
-
-
-
 	triggered_planet_modifier = {
 		potential = {
 			has_trait = trait_repugnant
@@ -1203,10 +1239,6 @@ supervisor = {
 		}
 	}
 }
-
-
-
-
 
 #Mogul
 mogul = {
@@ -1312,12 +1344,6 @@ mogul = {
 		 }			
 	}
 }
-
-
-
-
-
-
 
 techno_priest = {
 	category = specialist
@@ -1456,18 +1482,23 @@ socialist_trader = {					#By Hypno and Broad
 		trade_value_add = 5
 	}
 
+	triggered_planet_modifier = {
+		potential = {
+			OR = {
+				has_trait = trait_thrifty
+				has_trait = trait_nuumismatic_administration
+			}
+		}
+		modifier = {
+			trade_value_add = 1.25
+		}
+	}
+
 	resources = {
-		category = planet_miners
+		category = planet_socialist_traders
 		produces = {
 			unity = 2
 		}
-		
-        produces = {
-             trigger = { owner = { is_lithoid = yes  }}
-             food = -2
-             minerals = 2
-        }		
-
 	}
 
 	weight = {
@@ -1786,18 +1817,23 @@ bank_manager = {					#By Hypno
 		trade_value_add = 5
 	}
 
+	triggered_planet_modifier = {
+		potential = {
+			OR = {
+				has_trait = trait_thrifty
+				has_trait = trait_nuumismatic_administration
+			}
+		}
+		modifier = {
+			trade_value_add = 1.25
+		}
+	}
+
 	resources = {
-		category = planet_miners
+		category = planet_bank_managers
 		produces = {
 			unity = 2
 		}
-		
-        produces = {
-             trigger = { owner = { is_lithoid = yes  }}
-             food = -2
-             minerals = 2
-        }		
-
 	}
 
 	weight = {


### PR DESCRIPTION
These were the bugs I found or were reported in the last few days in the bug channel which I managed to fix. As for now I am not sure that the subsidies were intended to not apply the upkeep, so I included those changes and applied them for the new jobs too. If they were intended the way they were before, I'll remove them from the PR if that's the case. A more complete list was added to the changelog, which I have attached here.

- Implemented changes to pop_jobs which reflect vanilla 2.7 changes. This means roboticists are consuming alloys instead of minerals, all subsidies edicts now apply the correct upkeep increase as in vanilla (previously the edict were basically free besides the influence).
- Applied trifty trait and nuumismatic administration traits to all jobs added by SCM(bankers, mercenaries, socialist traders).
- Applied subsidies upkeep increase for jobs added by SCM(deep miners, labour heroes, geo engineers, xeno biologists).
- Changed subject_tax economic category to not inherit diplomacy upkeep multipliers. This caused the subject taxes to be increased masively for fanatic xenophobes and reduced dramatically for xenophile empires and nations with diplomacy opener.
- Added to economic categories for bankers and socialist traders since they would receive productivity increases from miners, specifically in the case of subsidies.